### PR TITLE
Hotfix double full regressions

### DIFF
--- a/.buildkite/bin/regress-metahooks.sh
+++ b/.buildkite/bin/regress-metahooks.sh
@@ -119,6 +119,7 @@ elif [ "$1" == '--commands' ]; then
     if test -e /buildkite/DO_PR; then
       echo "Trigger came from submod repo pull request; use pr config"
       export CONFIG="pr --include-no-zircon-tests"
+
       # Must restrict to a single slice else they will ALL do the full regression(!)
       if [ "$REGSTEP" != 1 ]; then
         echo "Full regressions only run as 'Regress 1'"
@@ -141,10 +142,11 @@ elif [ "$1" == '--commands' ]; then
       echo "Trigger came from aha repo step '$REGSTEP'; use $CONFIG";
 
     else
-      echo "Trigger came from OTHER, use default and/or config='$CONFIG'"
-      if [ "$REGSTEP" == 2 -o "$REGSTEP" == 3 ]; then
-        echo "oops no REGSTEP='$REGSTEP', not doing regressions"
-        DO_AR=False
+      echo "Trigger came from OTHER and (CONFIG != pr_aha): use default and/or config='$CONFIG'"
+
+      # Must restrict to a single slice else they will ALL do the requested CONFIG
+      if [ "$REGSTEP" != 1 ]; then
+        DO_AR=False  # I.e. ? don't do aha regressions for this REGSTEP ? right ?
       fi
       CONFIG="$CONFIG --include-no-zircon-tests"
     fi


### PR DESCRIPTION
Somebody wrote some sloppy code (it was me, I was the somebody).

As a result, the weekly full-regression test currently runs TWO REDUNDANT SETS of full regressions, one as "Fast" and one as "Regress 1," and each one requiring 26 hours of compute time
* https://buildkite.com/stanford-aha/aha-flow/builds/11831
* https://buildkite.com/stanford-aha/aha-flow/builds/11813
* https://buildkite.com/stanford-aha/aha-flow/builds/11798
* https://buildkite.com/stanford-aha/aha-flow/builds/11894

This hotfix cleans up the bad code and restores the original behavior: *one* full regression per week, running as "Regress 1."
* https://buildkite.com/stanford-aha/aha-flow/builds/11904

