### PR TITLE
Small optimization for regress.py

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,14 +5,10 @@ env:
   # Default config is "pr_aha"
   CONFIG: ${CONFIG:-pr_aha}
 
-  # RSTEPS: "build gold 0 1 2 3 4 5 6 7 8 9"  # gold + fast + regress 1-9
-  # RSTEPS: "gold 0 1 2 3"  # gold + fast + regress 1-3, skipping the build stage
+  # RSTEPS env var tells which configs to run and in what order.
+  # RSTEP "0" is the "fast" config; "1-9" decodes to configs pr_aha1-9
   #
-  # Analaysis indicates that, given these times for the nine regressions
-  # { 165,98,113,124,155,147,159,135,142 }  (from build 12226)
-  # an optimal least-time least-distance ordering might be
-  #      ORDER='125637894' TIME: 335 DIST: 4 (final)
-  # See kiwi:~steveri/tmpdir/optimal9/opt.c
+  # For optimal-ordering notes/info, see kiwi:~steveri/tmpdir/optimal9/opt.c
   #   (cc opt.c; a.out 9) |& grep final | sort -nk3,3 -nk5,5
   #
   RSTEPS: ${RSTEPS:-gold 0 1 2 3 4 6 5 8 7 9}

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -14,7 +14,7 @@ env:
   #
   # RSTEPS: "gold 0 1 2 3 4 5 6 7 8 9"  # gold + fast + regress 1-9
   # RSTEPS: "gold 0 1 2 3"  # gold + fast + regress 1-3
-  RSTEPS: ${RSTEPS:-gold 0 1 2 3 4 6 5 9 7 8}
+  RSTEPS: ${RSTEPS:-gold 0 1 2 3 4 6 5 8 7 9}
 
   MAX_AGENTS: 4  # How many agents do we get to use for regression steps?
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -14,7 +14,7 @@ env:
   #
   # RSTEPS: "gold 0 1 2 3 4 5 6 7 8 9"  # gold + fast + regress 1-9
   # RSTEPS: "gold 0 1 2 3"  # gold + fast + regress 1-3
-  RSTEPS: ${RSTEPS:-gold 0 1 2 3 4 6 5 8 7 9}
+  RSTEPS: ${RSTEPS:-gold 0 1 2 3 4 6 5 9 7 8}
 
   MAX_AGENTS: 4  # How many agents do we get to use for regression steps?
 

--- a/aha/bin/app
+++ b/aha/bin/app
@@ -193,7 +193,7 @@ if [ "$SUITE" ]; then
         [ "$DBG" ] && hline 72
 
         # Note $ZIRCON is either "" or " --no-zircon"
-        (echo "$suites" | egrep ^"$s" | awk -F, '{
+        (echo "$suites" | egrep "^$s," | awk -F, '{
           suite=$1; group=$2; app=$3; size=$4; $1=$2=$3=$4="";
           gsub(/^ */, "", $0); parms = $0
           printf("'$bn' %s \"%s\" %s\n", size, app, parms ZIRCON)

--- a/aha/util/regress.py
+++ b/aha/util/regress.py
@@ -394,7 +394,7 @@ def feature_support_check(testname, E64_mode_on, E64_multi_bank_mode_on):
     Once done, please add the test to E64_supported_tests in regress_tests/tests.py
     '''
     if E64_mode_on:
-        assert testname in Tests().E64_supported_tests, err1
+        assert testname in Tests.E64_supported_tests, err1
 
     err2 = '''f"ERROR: E64 multi-bank mode not yet supported for {testname}.
     Please make the necessary changes in Halide-to-Hardware and application_parameters.json.
@@ -402,7 +402,7 @@ def feature_support_check(testname, E64_mode_on, E64_multi_bank_mode_on):
     Once done, please add the test to E64_MB_supported_tests in regress_tests
     '''
     if E64_multi_bank_mode_on:
-        assert testname in Tests().E64_MB_supported_tests, err2
+        assert testname in Tests.E64_MB_supported_tests, err2
         assert E64_mode_on, f"ERROR: E64 multi-bank mode requires E64 mode to be enabled. Please add _E64 to the test name"
 
 
@@ -828,9 +828,6 @@ def dispatch(args, extra_args=None):
     external_mu_tests_fp = imported_tests.external_mu_tests_fp
     hardcoded_dense_tests = imported_tests.hardcoded_dense_tests
     no_zircon_sparse_tests = imported_tests.no_zircon_sparse_tests
-
-#     E64_supported_tests = imported_tests.E64_supported_tests
-#     E64_MB_supported_tests = imported_tests.E64_MB_supported_tests
 
     # No zircon flag (generate default layout)
     if args.no_zircon:

--- a/aha/util/regress.py
+++ b/aha/util/regress.py
@@ -1,18 +1,23 @@
+import sys, os
 from pathlib import Path
-import re
-import json
 import subprocess
-import sys
-import os
-from tabulate import tabulate
-import time
-import tempfile
-import glob
-from collections import defaultdict
-import shutil
-import toml
 from aha.util.regress_tests.tests import Tests
-import copy
+from aha.util.regress_util import gen_garnet
+from aha.util.regress_util import generate_sparse_bitstreams
+from aha.util.regress_util import format_concat_tiles
+from aha.util.regress_util import test_sparse_app
+from aha.util.regress_util import test_dense_app
+from aha.util.regress_util import test_hardcoded_dense_app
+from aha.util.regress_util import info
+global info
+
+def report_ongoing_failures(failed_tests):
+    '''Keep track of which tests have failed already, if any'''
+    if failed_tests:
+        print(f"+++ {len(failed_tests)} FAILED TESTS SO FAR")
+        for ft in failed_tests: print("  ", ft)
+    else:
+        print(f"--- NO FAILED TESTS (YET)")
 
 def add_subparser(subparser):
     parser = subparser.add_parser(Path(__file__).stem, add_help=False)
@@ -31,777 +36,16 @@ def add_subparser(subparser):
     parser.add_argument("--no-zircon", action="store_true")
     parser.set_defaults(dispatch=dispatch)
 
-
-def buildkite_filter(s):
-    return re.sub("^---", " ---", s, flags=re.MULTILINE)
-
-
-def buildkite_call(command, env={}, return_output=False, out_file=None):
-    print("Command:",' '.join(command), flush=True)
-    env = {**os.environ.copy(), **env}
-    for retry in [1, 2, 3]:  # In case of SIG error, retry up to three times
-        try:
-            if return_output:
-                app = subprocess.run(
-                    command,
-                    check=True,
-                    text=True,
-                    env=env,
-                    stdout=out_file,
-                )
-            else:
-                app = subprocess.run(
-                    command,
-                    check=True,
-                    text=True,
-                    env=env,
-                )
-            break
-        except subprocess.CalledProcessError as e:
-            retry_sigs = [ 'SIGSEGV','SIGBUS','SIGABRT']; found_retry_sig = False
-            for rs in retry_sigs:
-                if rs in str(e): found_retry_sig = True
-
-            if found_retry_sig:
-                print(f'\n\n{e}\n')  # Print the error msg
-                print(f'*** ERROR subprocess died {retry} time(s) with one of {retry_sigs}')
-                print('*** Will retry three times, then give up.\n\n')
-
-                # if retry == 3: raise
-                # - No! Don't raise the error! Higher-level aha.py has similar
-                # - three-retry catchall, resulting in up to nine retries ! (Right?)
-                # - Do this instead:
-                if retry == 3:
-                    assert False, 'ERROR: Three time loser'
-            else:
-                raise
-
-
-def gen_garnet(width, height, dense_only=False, using_matrix_unit=False, mu_datawidth=16, num_fabric_cols_removed=0, mu_oc_0=32):
-    print("--- Generating Garnet", flush=True)
-    start = time.time()
-    if not os.path.exists("/aha/garnet/garnet.v"):
-        # Daemon is no good if/when we build new/different verilog
-        buildkite_call("aha garnet --daemon kill".split())
-
-        # No garnet verilog yet, so build it now.
-        buildkite_args = [
-            "aha",
-            "garnet",
-            "--width", str(width),
-            "--height", str(height),
-            "--verilog",
-            "--use_sim_sram",
-            "--glb_tile_mem_size", str(128),
-        ]
-
-        if dense_only:
-            buildkite_args.append("--dense-only")
-
-        if using_matrix_unit:
-            buildkite_args.append("--using-matrix-unit")
-            buildkite_args.append("--mu-datawidth")
-            buildkite_args.append(str(mu_datawidth))
-            buildkite_args.append("--give-north-io-sbs")
-            buildkite_args.append("--num-fabric-cols-removed")
-            buildkite_args.append(str(num_fabric_cols_removed))
-            buildkite_args.append("--mu-oc-0")
-            buildkite_args.append(str(mu_oc_0))
-            buildkite_args.append("--include-E64-hw")
-            buildkite_args.append("--include-multi-bank-hw")
-            buildkite_args.append("--include-mu-glb-hw")
-            buildkite_args.append("--use-non-split-fifos")
-            buildkite_args.append("--exclude-glb-ring-switch")
-            buildkite_args.append("--pipeline-mu2cgra")
-
-        buildkite_call(buildkite_args)
-
-    return time.time() - start
-
-
-def generate_sparse_bitstreams(sparse_tests, width, height, seed_flow, data_tile_pairs, kernel_name, opal_workaround=False, unroll=1, using_matrix_unit=False, num_fabric_cols_removed=0, mu_oc_0=32):
-    if len(sparse_tests) == 0:
-        return 0
-
-    print(f"--- mapping all tests", flush=True)
-    start = time.time()
-    env_vars = {"PYTHONPATH": "/aha/garnet/", "EXHAUSTIVE_PIPE": "1"}
-    # env_vars = {"PYTHONPATH": "/aha/garnet/"}
-    start = time.time()
-    all_sam_graphs = [f"/aha/sam/compiler/sam-outputs/onyx-dot/{testname}.gv" for testname in sparse_tests]
-
-    if(seed_flow):
-        build_tb_cmd = [
-            "python",
-            "/aha/garnet/tests/test_memory_core/build_tb.py",
-            "--ic_fork",
-            "--sam_graph", *all_sam_graphs,
-            "--seed", f"{0}",
-            "--dump_bitstream",
-            "--add_pond",
-            "--combined",
-            "--pipeline_scanner",
-            "--base_dir",
-            "/aha/garnet/SPARSE_TESTS/",
-            "--just_glb",
-            "--dump_glb",
-            "--fiber_access",
-            "--width", str(width),
-            "--height", str(height),
-        ]
-        if opal_workaround:
-            build_tb_cmd.append("--opal-workaround")
-        if using_matrix_unit:
-            build_tb_cmd.append("--using-matrix-unit")
-            build_tb_cmd.append("--give-north-io-sbs")
-            build_tb_cmd.append("--num-fabric-cols-removed")
-            build_tb_cmd.append(str(num_fabric_cols_removed))
-            build_tb_cmd.append("--include-E64-hw")
-            build_tb_cmd.append("--use-non-split-fifos")
-            build_tb_cmd.append("--mu_oc_0")
-            build_tb_cmd.append(str(mu_oc_0))
-        buildkite_call(
-            build_tb_cmd,
-            env=env_vars,
-        )
-    else:
-        build_tb_cmd = [
-            "python",
-            "/aha/garnet/tests/test_memory_core/build_tb.py",
-            "--ic_fork",
-            "--sam_graph", *all_sam_graphs,
-            "--seed", f"{0}",
-            "--dump_bitstream",
-            "--add_pond",
-            "--combined",
-            "--pipeline_scanner",
-            "--base_dir",
-            "/aha/garnet/SPARSE_TESTS/",
-            "--just_glb",
-            "--dump_glb",
-            "--fiber_access",
-            "--give_tensor",
-            "--tensor_locs",
-            "/aha/garnet/SPARSE_TESTS/MAT_TMP_DIR",
-            "--width", str(width),
-            "--height", str(height),
-            "--kernel_name", kernel_name,
-            "--data_tile_pairs", *data_tile_pairs,
-            "--unroll", str(unroll),
-        ]
-        if opal_workaround:
-            build_tb_cmd.append("--opal-workaround")
-        if using_matrix_unit:
-            build_tb_cmd.append("--using-matrix-unit")
-            build_tb_cmd.append("--give-north-io-sbs")
-            build_tb_cmd.append("--num-fabric-cols-removed")
-            build_tb_cmd.append(str(num_fabric_cols_removed))
-            build_tb_cmd.append("--include-E64-hw")
-            build_tb_cmd.append("--use-non-split-fifos")
-            build_tb_cmd.append("--mu_oc_0")
-            build_tb_cmd.append(str(mu_oc_0))
-        buildkite_call(
-            build_tb_cmd,
-            env=env_vars,
-        )
-    time_map = time.time() - start
-    return time_map
-
-
-def format_concat_tiles(test, data_tile_pairs, kernel_name, pipeline_num=32, unroll=1):
-    script_path = "/aha/garnet/"
-    pairs_cpy = data_tile_pairs.copy()
-    all_tiles = []
-    num_list = []
-    test_l = []
-    tile_format = ""
-    for tile in pairs_cpy:
-        test_l.append(kernel_name + "-" + tile.replace("/", "_"))
-
-    for i in range(0, len(test_l), pipeline_num):
-        test_l_str = f"concat{i}"
-        tile_format_t = f"{kernel_name}-tile_{test_l_str}"
-        all_tiles.append(tile_format_t)
-
-        if i + pipeline_num < len(test_l):
-            test_l_s = test_l[i:i + pipeline_num]
-        else:
-            test_l_s = test_l[i:]
-        true_pipeline_num = len(test_l_s)
-        num_list.append(true_pipeline_num)
-        print(f"CONCATENATING TILES {test_l_s}")
-        subprocess.call(
-            [
-                "python",
-                "/aha/garnet/concat_tiles.py",
-                test,
-                kernel_name,
-                test_l_str,
-                str(unroll),
-                *test_l_s,
-            ],
-            cwd=script_path
-        )
-
-    return all_tiles, num_list
-
-
-def test_sparse_app(testname, seed_flow, data_tile_pairs,
-                    pipeline_num_l=None,
-                    opal_workaround=False,
-                    test="",
-                    test_dataset_runtime_dict=None,
-                    using_matrix_unit=False,
-                    mu_datawidth=16,
-                    num_fabric_cols_removed=0,
-                    mu_oc_0=32,
-                    ):
-    if test == "":
-        test = testname
-
-    print(f"--- {test} - glb testing")
-
-    env_vars = {"PYTHONPATH": "/aha/garnet/"}
-    if using_matrix_unit:
-        if num_fabric_cols_removed == 0:
-            env_vars["WEST_IN_IO_SIDES"] = "1"
-        env_vars["USING_MATRIX_UNIT"] = "1"
-        env_vars["INCLUDE_MU_GLB_HW"] = "1"
-        env_vars["MU_OC_0"] = str(mu_oc_0)
-        env_vars["MU_DATAWIDTH"] = str(mu_datawidth)
-
-    app_path = f"{testname}_0/GLB_DIR/{testname}_combined_seed_0"
-    print(app_path, flush=True)
-
-    try:
-        subprocess.call(["make", "clean"], cwd=app_path)
-    except:
-        pass
-
-    if(seed_flow):
-        print("RUNNING SEED FLOW", flush=True)
-        start = time.time()
-        buildkite_call(
-            ["aha", "test", app_path, "--sparse"], env=env_vars,
-        )
-        time_test = time.time() - start
-    else:
-        print("RUNNING SS FLOW", flush=True)
-        use_pipeline = False
-        if pipeline_num_l is not None:
-            assert len(pipeline_num_l) == len(data_tile_pairs), "Pipeline number list must be the same length as the number of tile pairs"
-            use_pipeline = True
-        else:
-            use_pipeline = False
-        start = time.time()
-        if use_pipeline:
-            data_tile_pairs = [f"{test}_{tile}/GLB_DIR/{test}_combined_seed_{tile}" for tile in data_tile_pairs]
-            # Dictionary grouping tile pairs by pipeline number
-            grouped_dict = defaultdict(list)
-            for tile_pair, pipeline_num in zip(data_tile_pairs, pipeline_num_l):
-                grouped_dict[pipeline_num].append(tile_pair)
-
-            # create cmd_list for each pipeline number
-            cmd_list = []
-            for pipeline_num, tile_pairs in grouped_dict.items():
-                # if list is longer than 64, split into batches of 64
-                tile_pair_batches = [tile_pairs[i:i + 64] for i in range(0, len(tile_pairs), 64)]
-                for tile_pair in tile_pair_batches:
-                    cmd_list.append(["aha", "test"] + tile_pair + ["--sparse", "--multiles", str(pipeline_num)])
-
-            if testname not in test_dataset_runtime_dict:
-                test_dataset_runtime_dict[testname] = defaultdict(float)
-        else:
-            data_tile_pairs = [f"{test}_{tile}/GLB_DIR/{test}_combined_seed_{tile}" for tile in data_tile_pairs]
-            # split into batches of 64
-            tile_pairs = [data_tile_pairs[i:i + 64] for i in range(0, len(data_tile_pairs), 64)]
-            cmd_list = []
-            # for each tile pair construct cmd
-            for tile_pair in tile_pairs:
-                cmd_list.append(["aha", "test"] + tile_pair + ["--sparse", "--multiles", str(1)])
-            if testname not in test_dataset_runtime_dict:
-                test_dataset_runtime_dict[testname] = defaultdict(float)
-
-        print(cmd_list)
-
-        for cmd in cmd_list:
-            if cmd is None:
-                continue
-            buildkite_call(cmd, env=env_vars)
-            command = "grep \"total time\" /aha/garnet/tests/test_app/run.log"
-            results = subprocess.check_output(command, shell=True, encoding='utf-8')
-            for result in results.split("\n"):
-                if testname in result:
-                    test_dataset_runtime_dict[testname][result.split(f"{testname}_")[1].split("-")[0]] += float(result.split("\n")[0].split(" ns")[0].split(" ")[-1])
-
-        time_test = time.time() - start
-    active_app_cycles, total_config_cycles, total_write_data_cycles = track_performance()
-    return 0, 0, time_test, active_app_cycles, total_config_cycles, total_write_data_cycles
-
-###########################################################################
-# "parse" utilities used by test_dense_app() and test_hardcoded_dense_app()
-
-# Dense ready-valid mode
-def parse_RV_mode(testname):
-    dense_ready_valid = False
-    if "_RV" in testname:
-        dense_ready_valid = True
-        testname = testname.replace("_RV", "")
-    return testname, dense_ready_valid
-
-# E64 mode
-def parse_E64_mode(testname):
-    E64_mode_on = False
-    if "_E64" in testname:
-        E64_mode_on = True
-        testname = testname.replace("_E64", "")
-    return testname, E64_mode_on
-
-# E64 MB mode
-def parse_E64_MB_mode(testname):
-    E64_multi_bank_mode_on = False
-    if "_MB" in testname:
-        E64_multi_bank_mode_on = True
-        testname = testname.replace("_MB", "")
-    return testname, E64_multi_bank_mode_on
-
-# External MU test parsing
-def parse_mu_cgra_test(testname):
-    assert " -> " in testname, f"ERROR: External MU test {testname} does not contain ' -> '. Please check the test name format. Format should be 'mu_testname -> cgra_testname'."
-    mu_test, cgra_test = testname.split(" -> ")
-    assert "-" in mu_test, f"ERROR: mu_test portion of {testname} does not contain '-'. Please check the test name format. Format should be 'model-layer', e.g., resnet18-submodule_2."
-    return mu_test, cgra_test
-
-# Voyager CGRA test parsing
-def parse_voyager_cgra_test(testname):
-    assert "::" in testname, f"ERROR: Voyager CGRA test {testname} does not contain '::'. Please check the test name format. Format should be 'voyager_testname::cgra_testname'."
-    voyager_cgra_test, cgra_test = testname.split("::")
-    return voyager_cgra_test, cgra_test
-
-# Parametrized test parsing (for running generic functions on various NN layers with different shapes)
-def parse_layer_parametrized_test(testname, keyword, layer_in=""):
-    layer = layer_in
-    if keyword in testname:
-        layer = testname
-        testname = f"apps/{keyword}"
-    return testname, layer
-
-def feature_support_check(testname, E64_mode_on, E64_multi_bank_mode_on):
-
-    err1 = f'''E64 mode not yet supported for app "{testname}".
-    Please make the necessary changes in Halide-to-Hardware and application_parameters.json.
-    See pointwise for example. Ensure that the E64 unroll is multiple of 4.
-    Once done, please add the test to E64_supported_tests in regress_tests/tests.py
-    '''
-    if E64_mode_on:
-        assert testname in Tests.E64_supported_tests, err1
-
-    err2 = '''f"ERROR: E64 multi-bank mode not yet supported for {testname}.
-    Please make the necessary changes in Halide-to-Hardware and application_parameters.json.
-    See pointwise for example. Ensure that the E64_MB unroll is multiple of 8.
-    Once done, please add the test to E64_MB_supported_tests in regress_tests
-    '''
-    if E64_multi_bank_mode_on:
-        assert testname in Tests.E64_MB_supported_tests, err2
-        assert E64_mode_on, f"ERROR: E64 multi-bank mode requires E64 mode to be enabled. Please add _E64 to the test name"
-
-
-def track_performance():
-    performance_summary_path = "/aha/garnet/tests/test_app/performance_summary.txt"
-    if not os.path.exists(performance_summary_path):
-        raise FileNotFoundError(f"Performance summary file not found: {performance_summary_path}")
-    with open(performance_summary_path) as f:
-        lines = [line.strip() for line in f]
-        clock_period = int(float(lines[1].split(": ")[1].split(' ns')[0]))
-        active_app_cycles = int(float(lines[2].split(": ")[1].split(' ns')[0]) / clock_period)
-        total_config_cycles = int(float(lines[3].split(": ")[1].split(' ns')[0]) / clock_period)
-        total_write_data_cycles = int(float(lines[4].split(": ")[1].split(' ns')[0]) / clock_period)
-
-    return active_app_cycles, total_config_cycles, total_write_data_cycles
-
-########################################################################
-# app tests
-
-def test_dense_app(
-  test, tgroup, width, height, env_parameters, extra_args, dense_only=False,
-  using_matrix_unit=False, mu_datawidth=16, num_fabric_cols_removed=0, mu_oc_0=32):
-
-    print(f"--- BEGIN test_dense_app {test}", flush=True)
-    test_orig = test
-
-    # FIXME/TODO the skip_cgra* information below should probably be in tests.py instead of here...?
-
-    # These tests skip CGRA mapping and pnr to save time.  We assume that the collateral
-    # was generated by a prior test. This means certain tests must be run in order.
-    skip_cgra_map_list = [
-        "resnet18-conv2d_mx_default_16 -> zircon_nop_post_conv5_x_kernel1_RV_E64_MB",
-        "resnet18-submodule_17 -> zircon_residual_relu_fp_post_conv5_x_kernel1_RV_E64_MB",
-        "resnet18-submodule_17 -> zircon_residual_relu_fp_post_conv5_x_kernel2_RV_E64_MB",
-        "resnet18-submodule_17 -> zircon_residual_relu_fp_post_conv5_x_kernel3_RV_E64_MB",
-        "resnet18-submodule -> zircon_dequantize_relu_fp_post_conv1_kernel1_RV_E64_MB",
-        "resnet18-submodule -> zircon_dequantize_relu_fp_post_conv1_kernel2_RV_E64_MB",
-        "resnet18-submodule -> zircon_dequantize_relu_fp_post_conv1_kernel3_RV_E64_MB",
-        "resnet18-submodule_19 -> zircon_deq_q_relu_fp_post_conv5_x_kernel1_RV_E64_MB",
-        "resnet18-submodule_18 -> zircon_deq_ResReLU_fp_post_conv5_x_kernel1_RV_E64_MB",
-        "resnet18-submodule_18 -> zircon_deq_ResReLU_fp_post_conv5_x_kernel2_RV_E64_MB",
-        "resnet18-submodule_18 -> zircon_deq_ResReLU_fp_post_conv5_x_kernel3_RV_E64_MB",
-        "resnet18-submodule_20 -> zircon_deq_ResReLU_fp_post_conv5_x_kernel1_RV_E64_MB",
-        "resnet18-submodule_20 -> zircon_deq_ResReLU_fp_post_conv5_x_kernel2_RV_E64_MB",
-        "resnet18-submodule_20 -> zircon_deq_ResReLU_fp_post_conv5_x_kernel3_RV_E64_MB",
-    ]
-    skip_cgra_pnr_list = copy.deepcopy(skip_cgra_map_list)
-
-    skip_cgra_map = test in skip_cgra_map_list
-    skip_cgra_pnr = test in skip_cgra_pnr_list
-
-    # These tests skip output regs for easier PnR
-    skip_output_pipeline_regs = test in [
-        "apps/get_apply_e8m0_scale_fp_RV_E64_MB",
-        "apps/maxpooling_dense_rv_fp_RV_E64",
-        "apps/maxpooling_dense_rv_fp_RV_E64_MB",
-        "apps/get_e8m0_scale_accum_gb_input_RV_E64_MB",
-        "apps/apply_e8m0_scale_single_IO_RV_E64_MB",
-        "apps/apply_e8m0_scale_multi_IOs_RV_E64_MB",
-        "apps/stable_softmax_pass1_fp_RV_E64_MB",
-        "apps/stable_softmax_pass2_fp_RV_E64_MB",
-        "apps/stable_softmax_pass3_fp_RV_E64_MB",
-        "apps/layer_norm_pass1_fp_RV_E64_MB",
-        "apps/layer_norm_pass2_fp_RV_E64_MB",
-        "apps/gelu_pass1_mu_input_fp_RV_E64_MB",
-        "apps/gelu_pass2_fp_RV_E64_MB",
-        "apps/tanh_fp_RV_E64_MB",
-    ]
-
-    #------------------------------------------------------------------------
-    if 'external_mu_tests' in tgroup:
-        mu_test, test = parse_mu_cgra_test(test)
-    else:
-        mu_test = ""
-
-    if 'voyager_cgra_tests_fp' in tgroup:
-        voyager_cgra_test, test = parse_voyager_cgra_test(test)
-    else:
-        voyager_cgra_test = ""
-
-    test, dense_ready_valid = parse_RV_mode(test)
-    test, E64_mode_on = parse_E64_mode(test)
-    test, E64_multi_bank_mode_on = parse_E64_MB_mode(test)
-
-    layer = None
-    if tgroup == 'resnet_tests':
-        test = "apps/resnet_residual" if "residual" in test_orig else "apps/resnet_output_stationary"
-        layer = test_orig
-    elif tgroup == 'resnet_tests_fp':
-        test = "apps/conv2D_residual_fp" if "residual" in test_orig else "apps/conv2D_fp"
-        layer = test_orig
-    if tgroup == 'external_mu_tests':
-        test, layer = parse_layer_parametrized_test(test, "zircon_nop")
-    elif tgroup == 'external_mu_tests_fp':
-        test, layer = parse_layer_parametrized_test(test, "zircon_nop")
-        test, layer = parse_layer_parametrized_test(test, "zircon_dequantize_relu_fp", layer_in=layer)
-        test, layer = parse_layer_parametrized_test(test, "zircon_residual_relu_fp", layer_in=layer)
-        test, layer = parse_layer_parametrized_test(test, "zircon_psum_reduction_fp", layer_in=layer)
-        test, layer = parse_layer_parametrized_test(test, "zircon_dequant_fp", layer_in=layer)
-        test, layer = parse_layer_parametrized_test(test, "zircon_deq_ResReLU_quant_fp", layer_in=layer)
-        test, layer = parse_layer_parametrized_test(test, "zircon_deq_q_relu_fp", layer_in=layer)
-        test, layer = parse_layer_parametrized_test(test, "zircon_deq_ResReLU_fp", layer_in=layer)
-        test, layer = parse_layer_parametrized_test(test, "zircon_res_deq_ReLU_quant_fp", layer_in=layer)
-    elif tgroup == 'voyager_cgra_tests_fp':
-        test, layer = parse_layer_parametrized_test(test, "zircon_quant_fp")
-        test, layer = parse_layer_parametrized_test(test, "avgpool_layer_fp", layer_in=layer)
-        test, layer = parse_layer_parametrized_test(test, "fully_connected_layer_fp", layer_in=layer)
-
-    feature_support_check(test, E64_mode_on, E64_multi_bank_mode_on)
-
-    use_fp = '_fp' in tgroup
-    behavioral_MU = (tgroup == 'behavioral_mu_tests' or tgroup == 'behavioral_mu_tests_fp')
-    #------------------------------------------------------------------------
-
-    env_parameters = str(env_parameters)
-
-    # Note testname is for logging/display purposes only...!
-    testname = f'{test_orig}/{layer}' if layer is not None else test_orig
-    print(f"--- {testname} - compiling and mapping", flush=True)
-    app_path = "/aha/Halide-to-Hardware/apps/hardware_benchmarks/" + test
-    voyager_collateral_path = "/aha/voyager/compiled_collateral"
-    print(app_path, flush=True)
-
-    layer_array = [] if layer is None else ["--layer", layer]
-
-    if not(skip_cgra_map or skip_cgra_pnr):
-        try:
-            subprocess.call(["make", "clean"], cwd=app_path)
-        except:
-            pass
-
-    if mu_test is not None and mu_test != "":
-        # Clean up old mu_test collateral
-        os.system(f"rm -rf {voyager_collateral_path}/{mu_test}")
-
-    env_vars = {}
-    if dense_ready_valid:
-        env_vars["DENSE_READY_VALID"] = "1"
-        env_vars["PIPELINED"] = "0"
-        env_vars["MATCH_BRANCH_DELAY"] = "0"
-        print(f"\033[92mINFO: Running {test} in dense ready-valid mode\033[0m")
-
-    if E64_mode_on:
-        env_vars["E64_MODE_ON"] = "1"
-        print(f"\033[92mINFO: Running {test} with E64 MODE ON\033[0m")
-
-    if E64_multi_bank_mode_on:
-        print(f"\033[92mINFO: Running {test} with E64 MULTI BANK MODE ON\033[0m")
-        env_vars["E64_MULTI_BANK_MODE_ON"] = "1"
-
-    global info  # HA!
-    start = time.time()
-
-    # For conv1, we want the gold-check to be done using submodule_1's gold
-    # Submodule 1 and submodule of resnet18 should really be fused but cannot be due to complications in the quantized-training module
-    if mu_test == "resnet18-submodule":
-        buildkite_call(["aha", "map", test, "--chain", "--env-parameters", "", "--mu-test", "resnet18-submodule_1", "--skip-cgra-map", "--voyager-gold-model-only" ,"--skip-env-vars"] + layer_array)
-
-    if skip_cgra_map:
-        print(f"--- {testname} - SKIP CGRA MAP", flush=True)
-        info.append([f"{testname} - SKIP CGRA MAP", 0])
-        buildkite_call(["aha", "map", test, "--chain", "--env-parameters", env_parameters, "--mu-test", mu_test, "--voyager-cgra-test", voyager_cgra_test, "--skip-cgra-map"] + layer_array, env=env_vars)
-    else:
-        buildkite_call(["aha", "map", test, "--chain", "--env-parameters", env_parameters, "--mu-test", mu_test, "--voyager-cgra-test", voyager_cgra_test] + layer_array, env=env_vars)
-    time_compile = time.time() - start
-
-    print(f"--- {testname} - pnr and pipelining", flush=True)
-    start = time.time()
-
-    # To use daemon, call regress.py with args '--daemon auto'
-    # --- extra_args=['--daemon', 'auto']
-    use_daemon = []
-    if (extra_args):
-        if ('--daemon' in extra_args) and ('auto' in extra_args):
-            use_daemon = ["--daemon", "auto"]
-
-    buildkite_args = [
-        "aha",
-        "pnr",
-        test,
-        "--width", str(width),
-        "--height", str(height),
-        "--env-parameters", env_parameters,
-        "--mu-test", mu_test,
-    ] + use_daemon + layer_array
-
-    if dense_only:
-        buildkite_args.append("--dense-only")
-
-    env_vars = {}
-    if dense_ready_valid:
-        print(f"\033[92mINFO: Running {test} in dense ready-valid mode\033[0m")
-        env_vars["DENSE_READY_VALID"] = "1"
-        env_vars["EXHAUSTIVE_PIPE"] = "1"
-
-    if E64_mode_on:
-        print(f"\033[92mINFO: Running {test} with E64 MODE ON\033[0m")
-        env_vars["E64_MODE_ON"] = "1"
-
-    if E64_multi_bank_mode_on:
-        print(f"\033[92mINFO: Running {test} with E64 MULTI BANK MODE ON\033[0m")
-        env_vars["E64_MULTI_BANK_MODE_ON"] = "1"
-
-    if using_matrix_unit:
-        buildkite_args.append("--using-matrix-unit")
-        buildkite_args.append("--mu-datawidth")
-        buildkite_args.append(str(mu_datawidth))
-        buildkite_args.append("--give-north-io-sbs")
-        buildkite_args.append("--num-fabric-cols-removed")
-        buildkite_args.append(str(num_fabric_cols_removed))
-        buildkite_args.append("--mu-oc-0")
-        buildkite_args.append(str(mu_oc_0))
-        buildkite_args.append("--include-E64-hw")
-        buildkite_args.append("--include-multi-bank-hw")
-        buildkite_args.append("--include-mu-glb-hw")
-        buildkite_args.append("--use-non-split-fifos")
-        buildkite_args.append("--pipeline-mu2cgra")
-
-        env_vars["INCLUDE_E64_HW"] = "1"
-        env_vars["INCLUDE_MULTI_BANK_HW"] = "1"
-        env_vars["NUM_FABRIC_COLS_REMOVED"] = str(num_fabric_cols_removed)
-
-        if num_fabric_cols_removed == 0:
-            env_vars["WEST_IN_IO_SIDES"] = "1"
-
-        env_vars["USING_MATRIX_UNIT"] = "1"
-        env_vars["INCLUDE_MU_GLB_HW"] = "1"
-        env_vars["MU_OC_0"] = str(mu_oc_0)
-        env_vars["MU_DATAWIDTH"] = str(mu_datawidth)
-        env_vars["ADD_MU_INPUT_BUBBLES"] = "1"
-
-        if behavioral_MU:
-            env_vars["BEHAVIORAL_MATRIX_UNIT"] = "1"
-
-        if mu_test is not None and mu_test != "":
-            env_vars["VOYAGER_GOLD"] = "1"
-
-    if skip_cgra_pnr:
-        print(f"--- {testname} - SKIP CGRA PNR", flush=True)
-        info.append([f"{testname} - SKIP CGRA PNR", 0])
-        buildkite_args.append("--skip-cgra-pnr")
-
-    if skip_output_pipeline_regs:
-        print(f"--- {testname} - SKIP OUTPUT PIPELINE REGS", flush=True)
-        info.append([f"--- {testname} - SKIP OUTPUT PIPELINE REGS", 0])
-        buildkite_args.append("--no-output-pipelining")
-
-    buildkite_call(buildkite_args, env=env_vars)
-    time_map = time.time() - start
-
-    # Test visualization tool only for gaussian
-    print(f"--- {testname} - visualizing", flush=True)
-    if testname == "apps/gaussian_RV":
-        buildkite_call(["aha", "sta", test, "-v"], env=env_vars)
-
-    print(f"--- {testname} - glb testing", flush=True)
-    start = time.time()
-
-    if mu_test == "" or mu_test is None:
-        mu_test = "inactive"
-    if use_fp:
-        buildkite_call(["aha", "test", test, "--dense-fp", "--mu-test", mu_test, "--voyager-cgra-test", voyager_cgra_test] + layer_array, env=env_vars)
-    else:
-        buildkite_call(["aha", "test", test, "--mu-test", mu_test, "--voyager-cgra-test", voyager_cgra_test] + layer_array, env=env_vars)
-    time_test = time.time() - start
-
-    active_app_cycles, total_config_cycles, total_write_data_cycles = track_performance()
-    return time_compile, time_map, time_test, active_app_cycles, total_config_cycles, total_write_data_cycles
-
-
-def test_hardcoded_dense_app(
-        test, width, height, env_parameters, extra_args,
-        using_matrix_unit=False, mu_datawidth=16,
-        num_fabric_cols_removed=0, mu_oc_0=32):
-
-    print(f"--- BEGIN test_dense_app {test}", flush=True)
-    #------------------------------------------------------------------------
-    test, dense_ready_valid = parse_RV_mode(test)
-    test, E64_mode_on = parse_E64_mode(test)
-    test, E64_multi_bank_mode_on = parse_E64_MB_mode(test)
-    feature_support_check(test, E64_mode_on, E64_multi_bank_mode_on)
-    #------------------------------------------------------------------------
-
-    env_parameters = str(env_parameters)
-    testname = test
-    print(f"--- {testname}")
-    print(f"--- {testname} - skip compiling and mapping")
-    app_path = "/aha/Halide-to-Hardware/apps/hardware_benchmarks/" + test
-    print(app_path, flush=True)
-
-    layer_array = []
-
-    start = time.time()
-    time_compile = time.time() - start
-
-    print(f"--- {testname} - pnr and pipelining", flush=True)
-    start = time.time()
-    try:
-        subprocess.call(["make", "clean"], cwd=app_path)
-    except:
-        pass
-
-    try:
-        print(f"copying hardcoded bin folder", flush=True)
-        shutil.copytree(f"{app_path}/bin_hardcoded", f"{app_path}/bin")
-    except:
-        raise RuntimeError(f"[ERROR] Please don't delete hardcoded bin folder")
-
-    # To use daemon, call regress.py with args '--daemon auto'
-    # --- extra_args=['--daemon', 'auto']
-    use_daemon = []
-    if (extra_args):
-        if ('--daemon' in extra_args) and ('auto' in extra_args):
-            use_daemon = ["--daemon", "auto"]
-
-    print(f"--- {testname} - pnr and pipelining", flush=True)
-    start = time.time()
-
-    # To use daemon, call regress.py with args '--daemon auto'
-    # --- extra_args=['--daemon', 'auto']
-    use_daemon = []
-    if (extra_args):
-        if ('--daemon' in extra_args) and ('auto' in extra_args):
-            use_daemon = ["--daemon", "auto"]
-
-    buildkite_args = [
-        "aha",
-        "pnr",
-        test,
-        "--width", str(width),
-        "--height", str(height),
-        "--env-parameters", env_parameters,
-    ] + use_daemon + layer_array
-
-    # hardcoded tests don't use dense_only
-    # if dense_only:
-    #     buildkite_args.append("--dense-only")
-
-    env_vars = {}
-    if dense_ready_valid:
-        print(f"\033[92mINFO: Running {test} in dense ready-valid mode\033[0m")
-        env_vars["DENSE_READY_VALID"] = "1"
-        env_vars["EXHAUSTIVE_PIPE"] = "1"
-
-    if E64_mode_on:
-        print(f"\033[92mINFO: Running {test} with E64 MODE ON\033[0m")
-        env_vars["E64_MODE_ON"] = "1"
-
-    if E64_multi_bank_mode_on:
-        print(f"\033[92mINFO: Running {test} with E64 MULTI BANK MODE ON\033[0m")
-        env_vars["E64_MULTI_BANK_MODE_ON"] = "1"
-
-    if using_matrix_unit:
-        #TODO: Make these all env vars?
-        buildkite_args.append("--using-matrix-unit")
-        buildkite_args.append("--mu-datawidth")
-        buildkite_args.append(str(mu_datawidth))
-        buildkite_args.append("--give-north-io-sbs")
-        buildkite_args.append("--num-fabric-cols-removed")
-        buildkite_args.append(str(num_fabric_cols_removed))
-        buildkite_args.append("--mu-oc-0")
-        buildkite_args.append(str(mu_oc_0))
-        buildkite_args.append("--include-E64-hw")
-        buildkite_args.append("--include-multi-bank-hw")
-        buildkite_args.append("--include-mu-glb-hw")
-        buildkite_args.append("--use-non-split-fifos")
-        buildkite_args.append("--pipeline-mu2cgra")
-
-        env_vars["INCLUDE_E64_HW"] = "1"
-        env_vars["INCLUDE_MULTI_BANK_HW"] = "1"
-        env_vars["NUM_FABRIC_COLS_REMOVED"] = str(num_fabric_cols_removed)
-
-        if num_fabric_cols_removed == 0:
-            env_vars["WEST_IN_IO_SIDES"] = "1"
-
-        env_vars["USING_MATRIX_UNIT"] = "1"
-        env_vars["INCLUDE_MU_GLB_HW"] = "1"
-        env_vars["MU_OC_0"] = str(mu_oc_0)
-        env_vars["MU_DATAWIDTH"] = str(mu_datawidth)
-        env_vars["ADD_MU_INPUT_BUBBLES"] = "1"
-
-    buildkite_call(buildkite_args, env=env_vars)
-    time_map = time.time() - start
-
-    print(f"--- {testname} - glb testing", flush=True)
-    start = time.time()
-    buildkite_call(["aha", "test", test], env=env_vars)
-
-    time_test = time.time() - start
-    active_app_cycles, total_config_cycles, total_write_data_cycles = track_performance()
-    return time_compile, time_map, time_test, active_app_cycles, total_config_cycles, total_write_data_cycles
-
-
 def dispatch(args, extra_args=None):
+  try:
     seed_flow = not args.non_seed_flow
     use_pipeline = args.use_pipeline
     using_matrix_unit = args.using_matrix_unit
     mu_datawidth = args.mu_datawidth
     unroll = args.unroll
+
+    failed_tests = []
+    final_error = None
 
     # It's painful if we don't catch this up front! (E.g. missing vcs.)
     if "TOOL" in os.environ: TOOL = os.environ["TOOL"].lower()
@@ -820,7 +64,8 @@ def dispatch(args, extra_args=None):
 
     # For printing info at the end...
     global info  # HA!
-    info = []
+    # info = []  # DON'T DO THIS!!! Or else you lose your pointer to the One True Info in regress_util
+    info.clear()
 
     # For config definitions see regress_tests/tests.py
     imported_tests = Tests(args.config)
@@ -842,6 +87,9 @@ def dispatch(args, extra_args=None):
     external_mu_tests_fp = imported_tests.external_mu_tests_fp
     hardcoded_dense_tests = imported_tests.hardcoded_dense_tests
     no_zircon_sparse_tests = imported_tests.no_zircon_sparse_tests
+
+#     E64_supported_tests = imported_tests.E64_supported_tests
+#     E64_MB_supported_tests = imported_tests.E64_MB_supported_tests
 
     # No zircon flag (generate default layout)
     if args.no_zircon:
@@ -903,10 +151,12 @@ def dispatch(args, extra_args=None):
 
         test_dataset_runtime_dict = {}
 
+        import glob
         data_tile_pairs_lists = []
         for sparse_tile_pairs_list in args.sparse_tile_pairs_list:
             data_tile_pairs_lists.extend(glob.glob(sparse_tile_pairs_list))
 
+        import toml
         for data_tile_pairs_file in data_tile_pairs_lists:
             with open(data_tile_pairs_file, 'r') as f:
                 tile_pairs_dict = toml.load(f)
@@ -947,6 +197,7 @@ def dispatch(args, extra_args=None):
                     num_fabric_cols_removed=num_fabric_cols_removed,
                     mu_oc_0=mu_oc_0)
                 info.append([test + "_glb", t0 + t1 + t2, t0, t1, t2, t3, t4, t5])
+                report_ongoing_failures(failed_tests)
 
                 # remove the generated collateral for tiles that passed to avoid overrunning the disk
                 os.system(f"rm -rf /aha/garnet/SPARSE_TESTS/{test}*")
@@ -977,6 +228,7 @@ def dispatch(args, extra_args=None):
                 num_fabric_cols_removed=num_fabric_cols_removed,
                 mu_oc_0=mu_oc_0)
             info.append([test + "_glb", t0 + t1 + t2, t0, t1, t2, t3, t4, t5])
+            report_ongoing_failures(failed_tests)
 
     for test in [
             ('glb_tests_RV',        '_glb'),           *glb_tests_RV,
@@ -994,12 +246,22 @@ def dispatch(args, extra_args=None):
             continue
 
         unparsed_name = test
-        t0, t1, t2, t3, t4, t5 = test_dense_app(
-            test, tgroup, width, height, args.env_parameters, extra_args,
-            using_matrix_unit=using_matrix_unit, mu_datawidth=mu_datawidth,
-            num_fabric_cols_removed=num_fabric_cols_removed, mu_oc_0=mu_oc_0
-        )
-        info.append([unparsed_name+tsuffix, t0+t1+t2, t0, t1, t2, t3, t4, t5])
+
+        try:
+            t0, t1, t2, t3, t4, t5 = test_dense_app(
+                test, tgroup, width, height, args.env_parameters, extra_args,
+                using_matrix_unit=using_matrix_unit, mu_datawidth=mu_datawidth,
+                num_fabric_cols_removed=num_fabric_cols_removed, mu_oc_0=mu_oc_0
+            )
+            info.append([unparsed_name+tsuffix, t0+t1+t2, t0, t1, t2, t3, t4, t5])
+
+        except Exception as e:
+            print(f"--- FAILED TEST {unparsed_name}:\n{e}")
+            failed_tests += [unparsed_name]
+            final_error = e
+            info.append([unparsed_name+tsuffix+" FAIL"])
+
+        report_ongoing_failures(failed_tests)
 
     print(f"--- Processing app group hardcoded_dense_tests", flush=True)
     info.append(["APP GROUP hardcoded_dense_tests[]", 0])
@@ -1009,6 +271,7 @@ def dispatch(args, extra_args=None):
                         using_matrix_unit=using_matrix_unit, mu_datawidth=mu_datawidth,
                         num_fabric_cols_removed=num_fabric_cols_removed, mu_oc_0=mu_oc_0)
         info.append([unparsed_name + "_glb", t0 + t1 + t2, t0, t1, t2, t3, t4, t5])
+        report_ongoing_failures(failed_tests)
 
     # Skip unnecessary garnet build if tests don't exist, duh.
     tests_exist = True if [
@@ -1030,6 +293,7 @@ def dispatch(args, extra_args=None):
         print(f"\n\n---- NO-ZIRCON 1 ----\n\n")
         t = gen_garnet(width, height, dense_only=False, using_matrix_unit=False, num_fabric_cols_removed=0)
         info.append(["garnet (NO Zircon) with sparse and dense", t])
+        report_ongoing_failures(failed_tests)
 
         if no_zircon_sparse_tests:
             # See above for no_zircon_sparse_tests[]
@@ -1040,10 +304,12 @@ def dispatch(args, extra_args=None):
                                        seed_flow, data_tile_pairs, kernel_name,
                                        opal_workaround=args.opal_workaround, unroll=unroll)
             info.append(["gen_sparse_bitstreams_nz", t, 0, t, 0])  # Count this as "map" time
+            report_ongoing_failures(failed_tests)
 
             for test in no_zircon_sparse_tests:
                 t0, t1, t2, t3, t4, t5 = test_sparse_app(test, seed_flow, data_tile_pairs, opal_workaround=args.opal_workaround)
                 info.append([test + "_glb", t0 + t1 + t2, t0, t1, t2, t3, t4, t5])
+                report_ongoing_failures(failed_tests)
 
         # For dense tests, we run glb_tests, glb_tests_fp, resnet_tests, and resnet_tests_fp
 
@@ -1061,6 +327,7 @@ def dispatch(args, extra_args=None):
 
             t0, t1, t2, t3, t4, t5 = test_dense_app(test, tgroup, width, height, args.env_parameters, extra_args)
             info.append([test + "_glb", t0 + t1 + t2, t0, t1, t2, t3, t4, t5])
+            report_ongoing_failures(failed_tests)
 
     # Skip unnecessary garnet build if tests don't exist, duh.
     dense_only_tests_exist = True if glb_tests else False
@@ -1083,6 +350,7 @@ def dispatch(args, extra_args=None):
                 break
             t0, t1, t2, t3, t4, t5 = test_dense_app(test, width, height, args.env_parameters, extra_args, dense_only=True)
             info.append([test + "_glb dense only", t0 + t1 + t2, t0, t1, t2, t3, t4, t5])
+            report_ongoing_failures(failed_tests)
 
         for test in resnet_tests:
             # residual resnet test is not working with dense only mode
@@ -1090,9 +358,23 @@ def dispatch(args, extra_args=None):
                 t0, t1, t2, t3, t4, t5 = test_dense_app("apps/resnet_output_stationary",
                                             width, height, args.env_parameters, extra_args, layer=test)
                 info.append([test + "_glb dense only", t0 + t1 + t2, t0, t1, t2, t3, t4, t5])
+                report_ongoing_failures(failed_tests)
 
+  except Exception as e:
+      final_error = e
+
+  finally:
+    from tabulate import tabulate
+    sys.stderr.flush()
     print(f"+++ TIMING INFO", flush=True)
     print(tabulate(info, headers=["step", "total", "compile", "map", "test", "active app cyc.", "config cyc.", "wdata cyc."], floatfmt=".0f"), flush=True)
+
+    if failed_tests:
+        print(f"+++ FAILURES", flush=True)
+        for ft in failed_tests: print("  ", ft)
+
+    if final_error:
+        raise(final_error)
 
 
 def gather_tests(tags):

--- a/aha/util/regress_tests/README.md
+++ b/aha/util/regress_tests/README.md
@@ -1,0 +1,29 @@
+### What is tests.py?
+`tests.py` is responsible for supplying lists of tests to `regress.py`, i.e. if someone does `aha regress fast`, `regress.py` does something like
+```
+    from aha.util.regress_tests.tests import Tests
+    ...
+    imported_tests = Tests("fast")
+```
+At this point, `imported_tests` is a handle for class variables
+defining the `fast` config tests and setup, e.g.
+```
+  imported_tests.width, imported_tests.height = 8, 8
+  imported_tests..glb_tests_RV = ["tests/conv_2_1_RV","apps/pointwise_RV_E64"]
+  etc.
+```
+
+### Specifying custom configs
+`tests.py` can detect and interpret yaml or json strings as configs e.g. the user can do one or more of these to run a single app:
+```
+  aha regress   'width: 8\nheight: 8\nglb_tests:\n- apps/pointwise'    # yaml
+  aha regress '{"width":8,"height":8,"glb_tests":["apps/pointwise"]}'  # json
+```
+
+### Testing tests.py:
+
+Instead of pytest (for now), can use testconfigs.py to verify tests.py directly.  This should work equally well from kiwi or docker or wherever. `testconfigs` basically exercises many of the features of tests.py, e.g. correctly listing the various configs "full", "pr_aha1", "fast", etc. and correctly interpreting json or yaml
+command-line configs.
+```
+    python3 testconfigs.py |& less
+```

--- a/aha/util/regress_tests/tests.py
+++ b/aha/util/regress_tests/tests.py
@@ -44,7 +44,11 @@ class Tests:
         # Zircon specific parms; 'regress.py --no-zircon' ignores these
         cols_removed, mu_oc_0 = 12, 32
 
-        E64_supported_tests = [
+        vardic = vars().copy()
+        for key in Tests.groups(): vardic[key] = []  # Include groups() groups
+        return vardic
+
+    E64_supported_tests = [
             "apps/pointwise",
             "apps/pointwise_mu_io",
             "conv5_x",
@@ -67,8 +71,8 @@ class Tests:
             "apps/zircon_res_deq_ReLU_quant_fp",
             "apps/zircon_quant_fp",
             "apps/mu2glb_path_balance_test",
-        ]
-        E64_MB_supported_tests = [
+    ]
+    E64_MB_supported_tests = [
             "apps/pointwise",
             "apps/pointwise_mu_io",
             "apps/pointwise_custom_place_multibank",
@@ -89,10 +93,7 @@ class Tests:
             "apps/zircon_res_deq_ReLU_quant_fp",
             "apps/zircon_quant_fp",
             "apps/mu2glb_path_balance_test",
-        ]
-        vardic = vars().copy()
-        for key in Tests.groups(): vardic[key] = []  # Include groups() groups
-        return vardic
+    ]
 
     def groups():
         voyager_cgra_tests_fp = [

--- a/aha/util/regress_tests/tests.py
+++ b/aha/util/regress_tests/tests.py
@@ -94,7 +94,68 @@ class Tests:
         ]
         return vars().copy()
 
+    def groups(groupname):
+        voyager_cgra_tests_fp = [
+
+            "subgroup1",
+            # Standalone quantize layers
+            "resnet18-quantize_default_1::zircon_quant_fp_post_conv2x_RV_E64_MB",
+            "resnet18-quantize_default_3::zircon_quant_fp_post_conv2x_RV_E64_MB",
+            "resnet18-quantize_default_7::zircon_quant_fp_post_conv3x_RV_E64_MB",
+            "resnet18-quantize_default_11::zircon_quant_fp_post_conv4x_RV_E64_MB",
+            "resnet18-quantize_default_15::zircon_quant_fp_post_conv5x_RV_E64_MB",
+
+            "subgroup2",
+            # Average pooling layer
+            "resnet18-adaptive_avg_pool2d_default_1::avgpool_layer_fp_RV_E64_MB",
+
+            "subgroup3",
+            # Fully connected layer (K-DIM HOST TILING)
+            "resnet18-linear::fully_connected_layer_fp_kernel0_RV_E64_MB",
+            "resnet18-linear::fully_connected_layer_fp_kernel1_RV_E64_MB",
+        ]
+        return vars()[groupname].copy()
+
+    def group(self, groupname, subgroup=[]):
+        '''E.g. group("voyager_cgra_tests_fp", [2,3])'''
+        applist = []
+        group_info = Tests.groups(groupname)
+        for line in group_info:
+
+            # Subgroup info line e.g. line == "subgroup2"
+            if line.startswith('subgroup'):
+                sgi = int(line[8:]); continue
+
+            # Default is to include ALL apps
+            if not subgroup: applist += [line]
+
+            # If subgroups specified, only include apps in those subgroups
+            elif sgi in subgroup: applist += [line]
+
+        self.__dict__['voyager_cgra_tests_fp'] = applist
+        return True
+
+    def foo():
+        g=Tests.group('voyager_cgra_tests_fp')
+        for app in g: print('   ', app)
+        exit()
+
+
+
+#     print(groups('voyager_cgra_tests_fp'))
+#     exit()
+
+
+#     g=group('voyager_cgra_tests_fp', subgroup=[2,3])
+# #     print('---')
+#     for app in g: print('   ', app)
+#     exit()
+
+
     def __init__(self, testname="BLANK", zircon=True):
+        def addgroup(groupname, subgroup=[]):
+            self.group(groupname, subgroup)
+
         self.__dict__.update(Tests.configs_template())
 
         # Simplify: use pr_aha instead of "pr", "daily", or "pr_submod"
@@ -319,14 +380,10 @@ class Tests:
                 "apps/rope_pass1_fp_RV",
                 "apps/rope_pass2_fp_RV",
             ]
-            voyager_cgra_tests_fp = [
-                # Average pooling layer
-                "resnet18-adaptive_avg_pool2d_default_1::avgpool_layer_fp_RV_E64_MB",
+            addgroup("voyager_cgra_tests_fp", [2,3])
 
-                # Fully connected layer (K-DIM HOST TILING)
-                "resnet18-linear::fully_connected_layer_fp_kernel0_RV_E64_MB",
-                "resnet18-linear::fully_connected_layer_fp_kernel1_RV_E64_MB",
-            ]
+
+
 
         elif testname == "pr_aha9":
             width, height = 28, 16
@@ -862,6 +919,19 @@ def check_for_dupes(DBG=0):
             if DBG: print(dbg_result)
     assert not errors, 'Found duplicate apps, see ERROR messages above\n\n' + errors
 
+# Tests.foo()
+foo = Tests('pr_aha8').__dict__
+for app in foo['voyager_cgra_tests_fp']: print('        ',app)
+exit()
+for group in foo:
+    print('   ', group)
+    if type(foo[group]) is list:
+        for app in foo[group]: print('        ',app)
+
+
+exit()
+
+
 check_for_dupes(DBG=0)
 
 # app utility uses this to do things like e.g.
@@ -870,3 +940,33 @@ check_for_dupes(DBG=0)
 if __name__ == "__main__":
     import sys
     if '--exec' in sys.argv: exec(sys.argv[2])
+
+
+
+#             print(self.__dict__['voyager_cgra_tests_fp'])
+# 
+# 
+# 
+#             print(vars())
+#             print(vars()['voyager_cgra_tests_fp'])
+# 
+#             vars()['voyager_cgra_tests_fp'] = ['a','b']
+# 
+#             print(vars()['voyager_cgra_tests_fp'])
+#             print(self.__dict__)
+#             print(self.__dict__['voyager_cgra_tests_fp'])
+# 
+#             voyager_cgra_tests_fp = [
+#                 # Average pooling layer
+#                 "resnet18-adaptive_avg_pool2d_default_1::avgpool_layer_fp_RV_E64_MB",
+# 
+#                 # Fully connected layer (K-DIM HOST TILING)
+#                 "resnet18-linear::fully_connected_layer_fp_kernel0_RV_E64_MB",
+#                 "resnet18-linear::fully_connected_layer_fp_kernel1_RV_E64_MB",
+#             ]
+
+            # voyager_cgra_tests_fp = ['a1','1b']
+#             self.__dict__['voyager_cgra_tests_fp'] = ['c','d']
+
+            # self.__dict__['voyager_cgra_tests_fp'] = Tests.group('voyager_cgra_tests_fp', [2,3])
+            # self.group("voyager_cgra_tests_fp", [2,3])

--- a/aha/util/regress_tests/tests.py
+++ b/aha/util/regress_tests/tests.py
@@ -36,7 +36,7 @@ class Tests:
         glb_tests_fp = []
         resnet_tests = []
         resnet_tests_fp = []
-        voyager_cgra_tests_fp = []
+        # voyager_cgra_tests_fp = []
         behavioral_mu_tests = []
         external_mu_tests = []
         external_mu_tests_fp = []
@@ -92,9 +92,14 @@ class Tests:
             "apps/zircon_quant_fp",
             "apps/mu2glb_path_balance_test",
         ]
-        return vars().copy()
+        vardic = vars().copy()
 
-    def groups(groupname):
+        # Include any and all groups defined in groups() method
+        g = Tests.groups().copy()
+        for key in g: vardic[key] = []
+        return vardic
+
+    def groups():
         voyager_cgra_tests_fp = [
 
             "subgroup1",
@@ -114,48 +119,9 @@ class Tests:
             "resnet18-linear::fully_connected_layer_fp_kernel0_RV_E64_MB",
             "resnet18-linear::fully_connected_layer_fp_kernel1_RV_E64_MB",
         ]
-        return vars()[groupname].copy()
-
-    def group(self, groupname, subgroup=[]):
-        '''E.g. group("voyager_cgra_tests_fp", [2,3])'''
-        applist = []
-        group_info = Tests.groups(groupname)
-        for line in group_info:
-
-            # Subgroup info line e.g. line == "subgroup2"
-            if line.startswith('subgroup'):
-                sgi = int(line[8:]); continue
-
-            # Default is to include ALL apps
-            if not subgroup: applist += [line]
-
-            # If subgroups specified, only include apps in those subgroups
-            elif sgi in subgroup: applist += [line]
-
-        self.__dict__['voyager_cgra_tests_fp'] = applist
-        return True
-
-    def foo():
-        g=Tests.group('voyager_cgra_tests_fp')
-        for app in g: print('   ', app)
-        exit()
-
-
-
-#     print(groups('voyager_cgra_tests_fp'))
-#     exit()
-
-
-#     g=group('voyager_cgra_tests_fp', subgroup=[2,3])
-# #     print('---')
-#     for app in g: print('   ', app)
-#     exit()
-
+        return vars().copy()
 
     def __init__(self, testname="BLANK", zircon=True):
-        def addgroup(groupname, subgroup=[]):
-            self.group(groupname, subgroup)
-
         self.__dict__.update(Tests.configs_template())
 
         # Simplify: use pr_aha instead of "pr", "daily", or "pr_submod"
@@ -214,14 +180,7 @@ class Tests:
                 "tensor3_mttkrp",
                 "tensor3_ttv",
             ]
-            voyager_cgra_tests_fp = [
-                # Standalone quantize layers
-                "resnet18-quantize_default_1::zircon_quant_fp_post_conv2x_RV_E64_MB",
-                "resnet18-quantize_default_3::zircon_quant_fp_post_conv2x_RV_E64_MB",
-                "resnet18-quantize_default_7::zircon_quant_fp_post_conv3x_RV_E64_MB",
-                "resnet18-quantize_default_11::zircon_quant_fp_post_conv4x_RV_E64_MB",
-                "resnet18-quantize_default_15::zircon_quant_fp_post_conv5x_RV_E64_MB",
-            ]
+            self.addgroup("voyager_cgra_tests_fp", [1])
             external_mu_tests_fp = [
                 # Conv1 (im2col-based, X-DIM HOST TILING)
                 "resnet18-submodule -> zircon_dequantize_relu_fp_post_conv1_kernel0_RV_E64_MB",
@@ -380,10 +339,7 @@ class Tests:
                 "apps/rope_pass1_fp_RV",
                 "apps/rope_pass2_fp_RV",
             ]
-            addgroup("voyager_cgra_tests_fp", [2,3])
-
-
-
+            self.addgroup("voyager_cgra_tests_fp", [2,3])
 
         elif testname == "pr_aha9":
             width, height = 28, 16
@@ -612,21 +568,7 @@ class Tests:
                 # TODO: Tests below are planned but not yet supported
                 # "conv2_x_fp", # not yet supported by zircon
             ]
-            voyager_cgra_tests_fp = [
-                # Standalone quantize layers
-                "resnet18-quantize_default_1::zircon_quant_fp_post_conv2x_RV_E64_MB",
-                "resnet18-quantize_default_3::zircon_quant_fp_post_conv2x_RV_E64_MB",
-                "resnet18-quantize_default_7::zircon_quant_fp_post_conv3x_RV_E64_MB",
-                "resnet18-quantize_default_11::zircon_quant_fp_post_conv4x_RV_E64_MB",
-                "resnet18-quantize_default_15::zircon_quant_fp_post_conv5x_RV_E64_MB",
-
-                # Average pooling layer
-                "resnet18-adaptive_avg_pool2d_default_1::avgpool_layer_fp_RV_E64_MB",
-
-                # Fully connected layer (K-DIM HOST TILING)
-                "resnet18-linear::fully_connected_layer_fp_kernel0_RV_E64_MB",
-                "resnet18-linear::fully_connected_layer_fp_kernel1_RV_E64_MB",
-            ]
+            self.addgroup("voyager_cgra_tests_fp")
             behavioral_mu_tests = [
                 "apps/pointwise_mu_io_RV_E64",
                 "apps/pointwise_mu_io_RV_E64_MB",
@@ -730,21 +672,7 @@ class Tests:
             glb_tests_RV = []
             glb_tests_fp_RV = []
             resnet_tests = []
-            voyager_cgra_tests_fp = [
-                # Standalone quantize layers
-                "resnet18-quantize_default_1::zircon_quant_fp_post_conv2x_RV_E64_MB",
-                "resnet18-quantize_default_3::zircon_quant_fp_post_conv2x_RV_E64_MB",
-                "resnet18-quantize_default_7::zircon_quant_fp_post_conv3x_RV_E64_MB",
-                "resnet18-quantize_default_11::zircon_quant_fp_post_conv4x_RV_E64_MB",
-                "resnet18-quantize_default_15::zircon_quant_fp_post_conv5x_RV_E64_MB",
-
-                # Average pooling layer
-                "resnet18-adaptive_avg_pool2d_default_1::avgpool_layer_fp_RV_E64_MB",
-
-                # Fully connected layer (K-DIM HOST TILING)
-                "resnet18-linear::fully_connected_layer_fp_kernel0_RV_E64_MB",
-                "resnet18-linear::fully_connected_layer_fp_kernel1_RV_E64_MB",
-            ]
+            self.addgroup("voyager_cgra_tests_fp")
             behavioral_mu_tests = [
                 "apps/mu2glb_path_balance_test_RV_E64",
                 "apps/pointwise_mu_io_RV_E64_MB",
@@ -919,17 +847,50 @@ def check_for_dupes(DBG=0):
             if DBG: print(dbg_result)
     assert not errors, 'Found duplicate apps, see ERROR messages above\n\n' + errors
 
-# Tests.foo()
-foo = Tests('pr_aha8').__dict__
-for app in foo['voyager_cgra_tests_fp']: print('        ',app)
-exit()
-for group in foo:
-    print('   ', group)
-    if type(foo[group]) is list:
-        for app in foo[group]: print('        ',app)
 
 
-exit()
+def addgroup(self, groupname, subgroup=[]):
+    '''E.g. addgroup("voyager_cgra_tests_fp", [2,3])'''
+    applist = []
+    group_info = Tests.groups()[groupname]
+    for line in group_info:
+
+        # Subgroup info line e.g. line == "subgroup2"
+        if line.startswith('subgroup'):
+            sgi = int(line[8:]); continue
+
+        # Default is to include ALL apps
+        if not subgroup: applist += [line]
+
+        # If subgroups specified, only include apps in those subgroups
+        elif sgi in subgroup: applist += [line]
+
+    self.__dict__['voyager_cgra_tests_fp'] = applist
+    return True
+
+Tests.addgroup = addgroup
+
+# def foo():
+#     g=Tests.group('voyager_cgra_tests_fp')
+#     for app in g: print('   ', app)
+#     exit()
+
+
+
+#     g=group('voyager_cgra_tests_fp', subgroup=[2,3])
+# #     print('---')
+#     for app in g: print('   ', app)
+#     exit()
+
+# # Tests.foo()
+# foo = Tests('pr_aha8').__dict__
+# for app in foo['voyager_cgra_tests_fp']: print('        ',app)
+# exit()
+# for group in foo:
+#     print('   ', group)
+#     if type(foo[group]) is list:
+#         for app in foo[group]: print('        ',app)
+# exit()
 
 
 check_for_dupes(DBG=0)
@@ -940,33 +901,3 @@ check_for_dupes(DBG=0)
 if __name__ == "__main__":
     import sys
     if '--exec' in sys.argv: exec(sys.argv[2])
-
-
-
-#             print(self.__dict__['voyager_cgra_tests_fp'])
-# 
-# 
-# 
-#             print(vars())
-#             print(vars()['voyager_cgra_tests_fp'])
-# 
-#             vars()['voyager_cgra_tests_fp'] = ['a','b']
-# 
-#             print(vars()['voyager_cgra_tests_fp'])
-#             print(self.__dict__)
-#             print(self.__dict__['voyager_cgra_tests_fp'])
-# 
-#             voyager_cgra_tests_fp = [
-#                 # Average pooling layer
-#                 "resnet18-adaptive_avg_pool2d_default_1::avgpool_layer_fp_RV_E64_MB",
-# 
-#                 # Fully connected layer (K-DIM HOST TILING)
-#                 "resnet18-linear::fully_connected_layer_fp_kernel0_RV_E64_MB",
-#                 "resnet18-linear::fully_connected_layer_fp_kernel1_RV_E64_MB",
-#             ]
-
-            # voyager_cgra_tests_fp = ['a1','1b']
-#             self.__dict__['voyager_cgra_tests_fp'] = ['c','d']
-
-            # self.__dict__['voyager_cgra_tests_fp'] = Tests.group('voyager_cgra_tests_fp', [2,3])
-            # self.group("voyager_cgra_tests_fp", [2,3])

--- a/aha/util/regress_tests/tests.py
+++ b/aha/util/regress_tests/tests.py
@@ -40,7 +40,6 @@ class Tests:
         external_mu_tests = []
         external_mu_tests_fp = []
         hardcoded_dense_tests = []
-        # no_zircon_sparse_tests = []
 
         # Zircon specific parms; 'regress.py --no-zircon' ignores these
         cols_removed, mu_oc_0 = 12, 32
@@ -837,28 +836,21 @@ def check_for_dupes(DBG=0):
             if DBG: print(dbg_result)
     assert not errors, 'Found duplicate apps, see ERROR messages above\n\n' + errors
 
-
-
 def addgroup(self, groupname, subgroup=[]):
-    '''E.g. addgroup("voyager_cgra_tests_fp", [2,3])'''
+    '''
+    Add groups defined in groups() to the Tests class dictionary.
+    E.g. addgroup("voyager_cgra_tests_fp", [2,3])
+    '''
     applist = []
     group_info = Tests.groups()[groupname]
     for line in group_info:
-
-        # Subgroup info line e.g. line == "subgroup2"
         if line.startswith('subgroup'):
             sgi = int(line[8:]); continue
-
-        # Default is to include ALL apps
-        if not subgroup: applist += [line]
-
-        # If subgroups specified, only include apps in those subgroups
-        elif sgi in subgroup: applist += [line]
-
-    # self.__dict__['voyager_cgra_tests_fp'] = applist
+        if not subgroup: applist += [line]       # Default is to include ALL apps
+        elif sgi in subgroup: applist += [line]  # Else only include specified subs
     self.__dict__[groupname] = applist
     return True
-Tests.addgroup = addgroup
+Tests.addgroup = addgroup  # Provide a handle so class methods can use it
 
 check_for_dupes(DBG=0)
 
@@ -868,29 +860,3 @@ check_for_dupes(DBG=0)
 if __name__ == "__main__":
     import sys
     if '--exec' in sys.argv: exec(sys.argv[2])
-
-
-# def foo():
-#     g=Tests.group('voyager_cgra_tests_fp')
-#     for app in g: print('   ', app)
-#     exit()
-
-
-
-#     g=group('voyager_cgra_tests_fp', subgroup=[2,3])
-# #     print('---')
-#     for app in g: print('   ', app)
-#     exit()
-
-# # Tests.foo()
-# foo = Tests('pr_aha8').__dict__
-# for app in foo['voyager_cgra_tests_fp']: print('        ',app)
-# exit()
-# for group in foo:
-#     print('   ', group)
-#     if type(foo[group]) is list:
-#         for app in foo[group]: print('        ',app)
-# exit()
-
-
-

--- a/aha/util/regress_tests/tests.py
+++ b/aha/util/regress_tests/tests.py
@@ -36,12 +36,11 @@ class Tests:
         glb_tests_fp = []
         resnet_tests = []
         resnet_tests_fp = []
-        # voyager_cgra_tests_fp = []
         behavioral_mu_tests = []
         external_mu_tests = []
         external_mu_tests_fp = []
         hardcoded_dense_tests = []
-        no_zircon_sparse_tests = []
+        # no_zircon_sparse_tests = []
 
         # Zircon specific parms; 'regress.py --no-zircon' ignores these
         cols_removed, mu_oc_0 = 12, 32
@@ -93,10 +92,7 @@ class Tests:
             "apps/mu2glb_path_balance_test",
         ]
         vardic = vars().copy()
-
-        # Include any and all groups defined in groups() method
-        g = Tests.groups().copy()
-        for key in g: vardic[key] = []
+        for key in Tests.groups(): vardic[key] = []  # Include groups() groups
         return vardic
 
     def groups():
@@ -118,6 +114,14 @@ class Tests:
             # Fully connected layer (K-DIM HOST TILING)
             "resnet18-linear::fully_connected_layer_fp_kernel0_RV_E64_MB",
             "resnet18-linear::fully_connected_layer_fp_kernel1_RV_E64_MB",
+        ]
+        # For sparse tests, we cherry pick some representative tests to run
+        no_zircon_sparse_tests = [
+            "vec_elemmul",
+            "mat_vecmul_ij",
+            "mat_elemadd_leakyrelu_exp",
+            "matmul_ikj",
+            "tensor3_mttkrp",
         ]
         return vars().copy()
 
@@ -252,14 +256,8 @@ class Tests:
         elif testname == "pr_aha5":
             width, height = 28, 16
             cols_removed, mu_oc_0 = 12, 32
-            # For sparse tests, we cherry pick some representative tests to run
-            no_zircon_sparse_tests = [
-                "vec_elemmul",
-                "mat_vecmul_ij",
-                "mat_elemadd_leakyrelu_exp",
-                "matmul_ikj",
-                "tensor3_mttkrp",
-            ]
+            self.addgroup("no_zircon_sparse_tests")
+
             # Tests below are non-zircon and won't run by default
             glb_tests = [
                 "apps/pointwise",
@@ -636,15 +634,7 @@ class Tests:
                 "resnet18-submodule_20 -> zircon_deq_ResReLU_fp_post_conv5_x_kernel2_RV_E64_MB",
                 "resnet18-submodule_20 -> zircon_deq_ResReLU_fp_post_conv5_x_kernel3_RV_E64_MB",
             ]
-
-            # For sparse tests, we cherry pick some representative tests to run
-            no_zircon_sparse_tests = [
-                "vec_elemmul",
-                "mat_vecmul_ij",
-                "mat_elemadd_leakyrelu_exp",
-                "matmul_ikj",
-                "tensor3_mttkrp",
-            ]
+            self.addgroup("no_zircon_sparse_tests")
 
         elif testname == "resnet":
             width, height = 28, 16
@@ -865,10 +855,20 @@ def addgroup(self, groupname, subgroup=[]):
         # If subgroups specified, only include apps in those subgroups
         elif sgi in subgroup: applist += [line]
 
-    self.__dict__['voyager_cgra_tests_fp'] = applist
+    # self.__dict__['voyager_cgra_tests_fp'] = applist
+    self.__dict__[groupname] = applist
     return True
-
 Tests.addgroup = addgroup
+
+check_for_dupes(DBG=0)
+
+# app utility uses this to do things like e.g.
+#     tests.py --exec "print(*Tests.configs_list)"  # list config names
+#     tests.py --exec "for c in Tests.configs_list: Tests.show_config(c)  # list config contents
+if __name__ == "__main__":
+    import sys
+    if '--exec' in sys.argv: exec(sys.argv[2])
+
 
 # def foo():
 #     g=Tests.group('voyager_cgra_tests_fp')
@@ -893,11 +893,4 @@ Tests.addgroup = addgroup
 # exit()
 
 
-check_for_dupes(DBG=0)
 
-# app utility uses this to do things like e.g.
-#     tests.py --exec "print(*Tests.configs_list)"  # list config names
-#     tests.py --exec "for c in Tests.configs_list: Tests.show_config(c)  # list config contents
-if __name__ == "__main__":
-    import sys
-    if '--exec' in sys.argv: exec(sys.argv[2])

--- a/aha/util/regress_tests/tests.py
+++ b/aha/util/regress_tests/tests.py
@@ -36,17 +36,16 @@ class Tests:
         glb_tests_fp = []
         resnet_tests = []
         resnet_tests_fp = []
+        voyager_cgra_tests_fp = []
         behavioral_mu_tests = []
         external_mu_tests = []
         external_mu_tests_fp = []
         hardcoded_dense_tests = []
+        no_zircon_sparse_tests = []
 
         # Zircon specific parms; 'regress.py --no-zircon' ignores these
         cols_removed, mu_oc_0 = 12, 32
-
-        vardic = vars().copy()
-        for key in Tests.groups(): vardic[key] = []  # Include groups() groups
-        return vardic
+        return vars().copy()
 
     E64_supported_tests = [
             "apps/pointwise",
@@ -94,36 +93,6 @@ class Tests:
             "apps/zircon_quant_fp",
             "apps/mu2glb_path_balance_test",
     ]
-
-    def groups():
-        voyager_cgra_tests_fp = [
-
-            "subgroup1",
-            # Standalone quantize layers
-            "resnet18-quantize_default_1::zircon_quant_fp_post_conv2x_RV_E64_MB",
-            "resnet18-quantize_default_3::zircon_quant_fp_post_conv2x_RV_E64_MB",
-            "resnet18-quantize_default_7::zircon_quant_fp_post_conv3x_RV_E64_MB",
-            "resnet18-quantize_default_11::zircon_quant_fp_post_conv4x_RV_E64_MB",
-            "resnet18-quantize_default_15::zircon_quant_fp_post_conv5x_RV_E64_MB",
-
-            "subgroup2",
-            # Average pooling layer
-            "resnet18-adaptive_avg_pool2d_default_1::avgpool_layer_fp_RV_E64_MB",
-
-            "subgroup3",
-            # Fully connected layer (K-DIM HOST TILING)
-            "resnet18-linear::fully_connected_layer_fp_kernel0_RV_E64_MB",
-            "resnet18-linear::fully_connected_layer_fp_kernel1_RV_E64_MB",
-        ]
-        # For sparse tests, we cherry pick some representative tests to run
-        no_zircon_sparse_tests = [
-            "vec_elemmul",
-            "mat_vecmul_ij",
-            "mat_elemadd_leakyrelu_exp",
-            "matmul_ikj",
-            "tensor3_mttkrp",
-        ]
-        return vars().copy()
 
     def __init__(self, testname="BLANK", zircon=True):
         self.__dict__.update(Tests.configs_template())
@@ -184,7 +153,14 @@ class Tests:
                 "tensor3_mttkrp",
                 "tensor3_ttv",
             ]
-            self.addgroup("voyager_cgra_tests_fp", [1])
+            voyager_cgra_tests_fp = [
+                # Standalone quantize layers
+                "resnet18-quantize_default_1::zircon_quant_fp_post_conv2x_RV_E64_MB",
+                "resnet18-quantize_default_3::zircon_quant_fp_post_conv2x_RV_E64_MB",
+                "resnet18-quantize_default_7::zircon_quant_fp_post_conv3x_RV_E64_MB",
+                "resnet18-quantize_default_11::zircon_quant_fp_post_conv4x_RV_E64_MB",
+                "resnet18-quantize_default_15::zircon_quant_fp_post_conv5x_RV_E64_MB",
+            ]
             external_mu_tests_fp = [
                 # Conv1 (im2col-based, X-DIM HOST TILING)
                 "resnet18-submodule -> zircon_dequantize_relu_fp_post_conv1_kernel0_RV_E64_MB",
@@ -256,8 +232,14 @@ class Tests:
         elif testname == "pr_aha5":
             width, height = 28, 16
             cols_removed, mu_oc_0 = 12, 32
-            self.addgroup("no_zircon_sparse_tests")
-
+            # For sparse tests, we cherry pick some representative tests to run
+            no_zircon_sparse_tests = [
+                "vec_elemmul",
+                "mat_vecmul_ij",
+                "mat_elemadd_leakyrelu_exp",
+                "matmul_ikj",
+                "tensor3_mttkrp",
+            ]
             # Tests below are non-zircon and won't run by default
             glb_tests = [
                 "apps/pointwise",
@@ -337,7 +319,14 @@ class Tests:
                 "apps/rope_pass1_fp_RV",
                 "apps/rope_pass2_fp_RV",
             ]
-            self.addgroup("voyager_cgra_tests_fp", [2,3])
+            voyager_cgra_tests_fp = [
+                # Average pooling layer
+                "resnet18-adaptive_avg_pool2d_default_1::avgpool_layer_fp_RV_E64_MB",
+
+                # Fully connected layer (K-DIM HOST TILING)
+                "resnet18-linear::fully_connected_layer_fp_kernel0_RV_E64_MB",
+                "resnet18-linear::fully_connected_layer_fp_kernel1_RV_E64_MB",
+            ]
 
         elif testname == "pr_aha9":
             width, height = 28, 16
@@ -566,7 +555,21 @@ class Tests:
                 # TODO: Tests below are planned but not yet supported
                 # "conv2_x_fp", # not yet supported by zircon
             ]
-            self.addgroup("voyager_cgra_tests_fp")
+            voyager_cgra_tests_fp = [
+                # Standalone quantize layers
+                "resnet18-quantize_default_1::zircon_quant_fp_post_conv2x_RV_E64_MB",
+                "resnet18-quantize_default_3::zircon_quant_fp_post_conv2x_RV_E64_MB",
+                "resnet18-quantize_default_7::zircon_quant_fp_post_conv3x_RV_E64_MB",
+                "resnet18-quantize_default_11::zircon_quant_fp_post_conv4x_RV_E64_MB",
+                "resnet18-quantize_default_15::zircon_quant_fp_post_conv5x_RV_E64_MB",
+
+                # Average pooling layer
+                "resnet18-adaptive_avg_pool2d_default_1::avgpool_layer_fp_RV_E64_MB",
+
+                # Fully connected layer (K-DIM HOST TILING)
+                "resnet18-linear::fully_connected_layer_fp_kernel0_RV_E64_MB",
+                "resnet18-linear::fully_connected_layer_fp_kernel1_RV_E64_MB",
+            ]
             behavioral_mu_tests = [
                 "apps/pointwise_mu_io_RV_E64",
                 "apps/pointwise_mu_io_RV_E64_MB",
@@ -634,7 +637,15 @@ class Tests:
                 "resnet18-submodule_20 -> zircon_deq_ResReLU_fp_post_conv5_x_kernel2_RV_E64_MB",
                 "resnet18-submodule_20 -> zircon_deq_ResReLU_fp_post_conv5_x_kernel3_RV_E64_MB",
             ]
-            self.addgroup("no_zircon_sparse_tests")
+
+            # For sparse tests, we cherry pick some representative tests to run
+            no_zircon_sparse_tests = [
+                "vec_elemmul",
+                "mat_vecmul_ij",
+                "mat_elemadd_leakyrelu_exp",
+                "matmul_ikj",
+                "tensor3_mttkrp",
+            ]
 
         elif testname == "resnet":
             width, height = 28, 16
@@ -662,7 +673,21 @@ class Tests:
             glb_tests_RV = []
             glb_tests_fp_RV = []
             resnet_tests = []
-            self.addgroup("voyager_cgra_tests_fp")
+            voyager_cgra_tests_fp = [
+                # Standalone quantize layers
+                "resnet18-quantize_default_1::zircon_quant_fp_post_conv2x_RV_E64_MB",
+                "resnet18-quantize_default_3::zircon_quant_fp_post_conv2x_RV_E64_MB",
+                "resnet18-quantize_default_7::zircon_quant_fp_post_conv3x_RV_E64_MB",
+                "resnet18-quantize_default_11::zircon_quant_fp_post_conv4x_RV_E64_MB",
+                "resnet18-quantize_default_15::zircon_quant_fp_post_conv5x_RV_E64_MB",
+
+                # Average pooling layer
+                "resnet18-adaptive_avg_pool2d_default_1::avgpool_layer_fp_RV_E64_MB",
+
+                # Fully connected layer (K-DIM HOST TILING)
+                "resnet18-linear::fully_connected_layer_fp_kernel0_RV_E64_MB",
+                "resnet18-linear::fully_connected_layer_fp_kernel1_RV_E64_MB",
+            ]
             behavioral_mu_tests = [
                 "apps/mu2glb_path_balance_test_RV_E64",
                 "apps/pointwise_mu_io_RV_E64_MB",
@@ -836,22 +861,6 @@ def check_for_dupes(DBG=0):
                     dbg_result = ' - FOUND DUPES! ERROR!'
             if DBG: print(dbg_result)
     assert not errors, 'Found duplicate apps, see ERROR messages above\n\n' + errors
-
-def addgroup(self, groupname, subgroup=[]):
-    '''
-    Add groups defined in groups() to the Tests class dictionary.
-    E.g. addgroup("voyager_cgra_tests_fp", [2,3])
-    '''
-    applist = []
-    group_info = Tests.groups()[groupname]
-    for line in group_info:
-        if line.startswith('subgroup'):
-            sgi = int(line[8:]); continue
-        if not subgroup: applist += [line]       # Default is to include ALL apps
-        elif sgi in subgroup: applist += [line]  # Else only include specified subs
-    self.__dict__[groupname] = applist
-    return True
-Tests.addgroup = addgroup  # Provide a handle so class methods can use it
 
 check_for_dupes(DBG=0)
 

--- a/aha/util/regress_util.py
+++ b/aha/util/regress_util.py
@@ -369,7 +369,7 @@ def feature_support_check(testname, E64_mode_on, E64_multi_bank_mode_on):
     Once done, please add the test to E64_supported_tests in regress_tests/tests.py
     '''
     if E64_mode_on:
-        assert testname in Tests().E64_supported_tests, err1
+        assert testname in Tests.E64_supported_tests, err1
 
     err2 = '''f"ERROR: E64 multi-bank mode not yet supported for {testname}.
     Please make the necessary changes in Halide-to-Hardware and application_parameters.json.
@@ -377,7 +377,7 @@ def feature_support_check(testname, E64_mode_on, E64_multi_bank_mode_on):
     Once done, please add the test to E64_MB_supported_tests in regress_tests
     '''
     if E64_multi_bank_mode_on:
-        assert testname in Tests().E64_MB_supported_tests, err2
+        assert testname in Tests.E64_MB_supported_tests, err2
         assert E64_mode_on, f"ERROR: E64 multi-bank mode requires E64 mode to be enabled. Please add _E64 to the test name"
 
 


### PR DESCRIPTION
This simple optimization prevents unnecessary compute time and memory waste in `regress.py` runs.

Previously, each call to `feature_support_check()` would build TWO `Tests()` class objects, just to load constant list objects `E64_supported_tests*`. And, because `feature_support_check()` must be called at least once per test, then e.g. 12 tests means 24 full dynamic `Tests()` objects get created.

This new code uses the already-existing static `Tests` class object instead of creating e.g. 24 dynamic objects, which should cut down on `regress.py` memory usage and management, garbage collection, etc.

In addition I have used this opportunity to make a couple of other small inconsequential changes:
- fixed a small typo/bug in `app` utility
- cleaned up some comments in `pipeline.yml`
- added a README file for `regress.py`
