### PR TITLE
Missing comma in tests.py crashes weekly regressions

### DIFF
--- a/aha/util/regress_tests/tests.py
+++ b/aha/util/regress_tests/tests.py
@@ -803,7 +803,7 @@ class Tests:
                 # LLaMA Prefill Softmax layers
                 "llama_prefill-softmax_1::stable_softmax_pass1_fp_llama_prefill_RV_E64_MB",
                 "llama_prefill-softmax_1::stable_softmax_pass2_fp_llama_prefill_RV_E64_MB",
-                "llama_prefill-softmax_1::stable_softmax_pass3_fp_llama_prefill_RV_E64_MB"
+                "llama_prefill-softmax_1::stable_softmax_pass3_fp_llama_prefill_RV_E64_MB",
 
                 # LLaMA Prefill SiLU
                 "llama_prefill-silu::add_gelu_pass2_fp_llama_prefill_RV_E64_MB",


### PR DESCRIPTION
Oops look there is a comma missing in `tests.py`

Weekly regressions will fail until/unless this gets fixed e.g.
<https://buildkite.com/stanford-aha/aha-flow/builds/13124#019e34bc-6fd4-4a9c-b201-11f73667bfec>
```
FAILED TEST llama_prefill-softmax_1::stable_softmax_pass3_fp_llama_prefill_RV_E64_MBllama_prefill-silu::add_gelu_pass2_fp_llama_prefill_RV_E64_MB:
too many values to unpack (expected 2)
```

We should just go ahead and push this through but of course we need one of you to approve first, thanks!